### PR TITLE
Implementa cenários por margem mensal e trimestral

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor="#0A84FF"
+backgroundColor="#FFFFFF"
+secondaryBackgroundColor="#F6F8FC"
+textColor="#0F172A"
+font="sans serif"

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,12 @@
+# Checklist de Verificação
+
+1. Dados carregam via GitHub raw, arquivo local ou upload.
+2. Datas e valores são normalizados corretamente.
+3. Devoluções de compra reduzem o CMV.
+4. KPIs e gráficos exibem o realizado de 2025.
+5. Simulação distribui LAT restante por mês (uniforme ou manual).
+6. Cálculo de PIS, COFINS, ICMS segue alíquotas 0,65%, 3% e 5%.
+7. IRPJ/CSLL trimestrais com adicional de IRPJ quando Base>60k.
+8. Meses realizados ficam travados; mês vigente pode ser simulado.
+9. Exportações CSV, XLSX e PDF disponíveis na simulação.
+10. Testes unitários e asserts internos passam.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ streamlit run app.py
 │  └─ test_calc.py
 ├─ bootstrap.sh
 └─ README.md
+
+### Streamlit Cloud
+1. Faça fork deste repositório no GitHub.
+2. No [Streamlit Cloud](https://streamlit.io/cloud), clique em "Deploy" e informe:
+   - Repository: `<seu-usuario>/SIMULA-AO-DE-FATURAMENTO`
+   - Branch: `main`
+   - Main file: `app.py`
+3. Defina as variáveis de ambiente se necessário e finalize o deploy.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,248 @@
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+from io import BytesIO
+from calc import (
+    prepare_dataframe,
+    compute_realizado,
+    calc_mes,
+    ultimo_yyyymm,
+    meses_simulaveis,
+    trimestre_de,
+    progresso_trimestre,
+    irpj_csll_trimestre,
+)
+
+st.set_page_config(page_title="Simulação de Faturamento 2025", layout="wide")
+st.markdown(
+    """
+<style>
+div.stMetric{border:1px solid #E0E0E0;padding:10px;border-radius:4px;background-color:#F6F8FC}
+</style>
+""",
+    unsafe_allow_html=True,
+)
+
+st.sidebar.header("Parâmetros GitHub")
+owner = st.sidebar.text_input("Owner", value="")
+repo = st.sidebar.text_input("Repo", value="SIMULACAO-DE-FATURAMENTO")
+branch = st.sidebar.text_input("Branch", value="main")
+path = st.sidebar.text_input("Path", value="resultado_eduardo_veiculos.xlsx")
+
+@st.cache_data(ttl=300)
+def load_data(owner: str, repo: str, branch: str, path: str):
+    if owner:
+        url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
+        try:
+            return pd.read_excel(url, engine="openpyxl")
+        except Exception:
+            st.warning("Falha ao carregar do GitHub.")
+    try:
+        return pd.read_excel(path, engine="openpyxl")
+    except Exception:
+        return None
+
+df = load_data(owner, repo, branch, path)
+if df is None:
+    uploaded = st.file_uploader("Envie a planilha resultado_eduardo_veiculos.xlsx", type="xlsx")
+    if uploaded:
+        df = pd.read_excel(uploaded, engine="openpyxl")
+
+if df is None:
+    st.stop()
+
+df = prepare_dataframe(df)
+realizado = compute_realizado(df)
+ultimo = ultimo_yyyymm(df)
+last_month = ultimo % 100
+
+def fmt_brl(v: float) -> str:
+    return f"R$ {v:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+MESES_PT = {
+    1: "Jan",
+    2: "Fev",
+    3: "Mar",
+    4: "Abr",
+    5: "Mai",
+    6: "Jun",
+    7: "Jul",
+    8: "Ago",
+    9: "Set",
+    10: "Out",
+    11: "Nov",
+    12: "Dez",
+}
+
+pagina = st.sidebar.selectbox("Página", ["Dashboard", "Simulação", "Notas/Detalhes"])
+
+if pagina == "Dashboard":
+    ano = st.sidebar.selectbox("Ano", [2025], index=0)
+    mes = st.sidebar.selectbox("Mês", list(range(1, 13)), index=max(last_month - 1, 0))
+    linha = realizado.loc[mes]
+    col1, col2, col3, col4, col5 = st.columns(5)
+    col1.metric("Entradas", fmt_brl(linha["CMV"]))
+    col2.metric("Saídas", fmt_brl(linha["FAT"]))
+    col3.metric("LAT", fmt_brl(linha["LAT"]))
+    col4.metric("Lucro Líquido", fmt_brl(linha["LL"]))
+    col5.metric("Consumo", fmt_brl(linha["CONSUMO"]))
+    mensal = realizado.copy()
+    mensal["Tributos"] = mensal[["PIS", "COFINS", "ICMS", "IRPJ", "CSLL"]].sum(axis=1)
+    fig = px.bar(mensal, x=mensal.index, y=["FAT", "CMV", "CONSUMO", "LAT", "Tributos", "LL"], barmode="stack")
+    fig.update_layout(xaxis_title="Mês", yaxis_title="R$")
+    st.plotly_chart(fig, use_container_width=True)
+
+elif pagina == "Simulação":
+    st.header("Cenários por Margem – mensal e trimestral")
+    lat_sim = st.session_state.setdefault("lat_sim", {})
+
+    fat_ytd = realizado.loc[1:last_month, "FAT"].sum()
+    lat_ytd = realizado.loc[1:last_month, "LAT"].sum()
+    col1, col2 = st.columns(2)
+    col1.metric("Faturado YTD", fmt_brl(fat_ytd))
+    col2.metric("LAT YTD", fmt_brl(lat_ytd))
+
+    col_mes, col_toggle = st.columns([4, 1])
+    with col_toggle:
+        sim_vigente = st.checkbox("Simular mês vigente", False)
+    meses_disp = meses_simulaveis(ultimo)
+    if sim_vigente and ultimo not in meses_disp:
+        meses_disp.insert(0, ultimo)
+    if not meses_disp:
+        st.info("Todos os meses de 2025 já estão realizados.")
+        st.stop()
+    with col_mes:
+        mes_atual = st.segmented_control(
+            "Meses simuláveis",
+            meses_disp,
+            key="mes_atual",
+            selection=st.session_state.get("mes_atual", meses_disp[0]),
+            format_func=lambda m: MESES_PT[m % 100],
+        )
+
+    lat_val = lat_sim.get(mes_atual, 0.0)
+    lat_input = st.number_input(
+        "LAT do mês (R$)",
+        min_value=0.0,
+        step=1000.0,
+        value=lat_val,
+        key=f"lat_{mes_atual}",
+    )
+    lat_sim[mes_atual] = lat_input
+    propagar = st.checkbox("Aplicar este LAT aos próximos meses")
+    if propagar:
+        for m in meses_disp:
+            if m >= mes_atual:
+                lat_sim[m] = lat_input
+
+    res_mes = calc_mes(lat_input)
+    cenarios = res_mes["cenarios"]
+    margens = [0.05, 0.10, 0.15, 0.20, 0.25, 0.30]
+    for i in range(0, 6, 2):
+        c1, c2 = st.columns(2)
+        for j, m in enumerate(margens[i:i+2]):
+            col = c1 if j == 0 else c2
+            with col:
+                st.markdown(f"**Margem {int(m*100)}%**")
+                st.metric("Faturamento", fmt_brl(cenarios[m]["FAT"]))
+                st.metric("Compras", fmt_brl(cenarios[m]["COMPRAS"]))
+
+    pis = res_mes["PIS"]
+    cofins = res_mes["COFINS"]
+    icms_ref = cenarios[0.20]["ICMS"]
+    c1, c2, c3 = st.columns(3)
+    c1.metric("PIS (mês)", fmt_brl(pis))
+    c2.metric("COFINS (mês)", fmt_brl(cofins))
+    c3.metric("ICMS (mês)", fmt_brl(icms_ref))
+    st.caption("*ICMS depende do faturamento (varia por margem)")
+
+    lat_total = {202500 + m: realizado.loc[m, "LAT"] for m in range(1, 13)}
+    lat_total.update(lat_sim)
+    tri_key = trimestre_de(mes_atual)
+    prog, total, faltantes = progresso_trimestre(lat_total, tri_key)
+    st.subheader("Obrigações do Trimestre")
+    st.markdown(f"**Completo {prog}/{total}**")
+    if prog < total:
+        st.warning("Complete os 3 meses para apurar o trimestre")
+        cols = st.columns(len(faltantes))
+        for idx, m in enumerate(faltantes):
+            if cols[idx].button(MESES_PT[m % 100], key=f"goto_{m}"):
+                st.session_state["mes_atual"] = m
+                st.experimental_rerun()
+    irpj, csll, fechamento = irpj_csll_trimestre(lat_total, tri_key)
+    c1, c2 = st.columns(2)
+    if mes_atual == fechamento and prog == total:
+        c1.metric(f"IRPJ – {MESES_PT[fechamento % 100]}", fmt_brl(irpj))
+        c2.metric(f"CSLL – {MESES_PT[fechamento % 100]}", fmt_brl(csll))
+    else:
+        c1.metric("IRPJ – trimestre", fmt_brl(0.0))
+        c2.metric("CSLL – trimestre", fmt_brl(0.0))
+
+    rows = []
+    for m in margens:
+        rows.append({"Item": f"Margem {int(m*100)}% FAT", "Valor": cenarios[m]["FAT"]})
+        rows.append({"Item": f"Margem {int(m*100)}% Compras", "Valor": cenarios[m]["COMPRAS"]})
+    rows.append({"Item": "PIS", "Valor": pis})
+    rows.append({"Item": "COFINS", "Valor": cofins})
+    rows.append({"Item": "ICMS (20%)", "Valor": icms_ref})
+    df_export = pd.DataFrame(rows)
+    csv = df_export.to_csv(index=False).encode("utf-8")
+    st.download_button("Exportar Resumo CSV", csv, f"resumo_{mes_atual}.csv", "text/csv")
+    try:
+        from reportlab.lib.pagesizes import A4
+        from reportlab.pdfgen import canvas
+        pdf_buffer = BytesIO()
+        c = canvas.Canvas(pdf_buffer, pagesize=A4)
+        c.drawString(30, 800, f"Resumo {MESES_PT[mes_atual % 100]} 2025")
+        text = c.beginText(30, 780)
+        for _, row in df_export.iterrows():
+            text.textLine(f"{row['Item']}: {fmt_brl(row['Valor'])}")
+        c.drawText(text)
+        c.showPage()
+        c.save()
+        pdf_buffer.seek(0)
+        st.download_button(
+            "Exportar Resumo PDF",
+            pdf_buffer,
+            f"resumo_{mes_atual}.pdf",
+            "application/pdf",
+        )
+    except Exception:
+        st.info("reportlab não disponível para PDF.")
+
+    if st.checkbox("Mostrar detalhes (opcional)"):
+        detalhes = []
+        for m in meses_disp:
+            latm = lat_sim.get(m, 0.0)
+            resm = calc_mes(latm)
+            cen20 = resm["cenarios"][0.20]
+            detalhes.append(
+                {
+                    "Mês": MESES_PT[m % 100],
+                    "LAT": latm,
+                    "FAT_20%": cen20["FAT"],
+                    "Compras_20%": cen20["COMPRAS"],
+                    "PIS": resm["PIS"],
+                    "COFINS": resm["COFINS"],
+                    "ICMS_20%": cen20["ICMS"],
+                }
+            )
+        st.dataframe(pd.DataFrame(detalhes))
+elif pagina == "Notas/Detalhes":
+    st.header("Notas/Detalhes")
+    meses = st.multiselect("Mês", sorted(df["mes"].unique()), default=sorted(df["mes"].unique()))
+    tipos = st.multiselect("Tipo Nota", sorted(df["tipo_nota"].unique()), default=sorted(df["tipo_nota"].unique()))
+    classifs = st.multiselect("Classificação", sorted(df["classificacao"].unique()), default=sorted(df["classificacao"].unique()))
+    filtrado = df[df["mes"].isin(meses) & df["tipo_nota"].isin(tipos) & df["classificacao"].isin(classifs)]
+    st.dataframe(filtrado)
+    csv = filtrado.to_csv(index=False).encode("utf-8")
+    st.download_button("Download CSV", csv, "notas_filtradas.csv", "text/csv")
+    towrite = BytesIO()
+    with pd.ExcelWriter(towrite, engine="openpyxl") as writer:
+        filtrado.to_excel(writer, index=False)
+    st.download_button(
+        "Download XLSX",
+        towrite.getvalue(),
+        "notas_filtradas.xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+set -e
+mkdir -p tests
+if [ ! -f app.py ]; then
+  cat <<'APP' > app.py
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+from io import BytesIO
+from calc import prepare_dataframe, compute_realizado, simulate
+
+st.set_page_config(page_title="Simulação de Faturamento 2025", layout="wide")
+
+st.sidebar.header("Parâmetros GitHub")
+owner = st.sidebar.text_input("Owner", value="")
+repo = st.sidebar.text_input("Repo", value="SIMULACAO-DE-FATURAMENTO")
+branch = st.sidebar.text_input("Branch", value="main")
+path = st.sidebar.text_input("Path", value="resultado_eduardo_veiculos.xlsx")
+
+@st.cache_data(ttl=300)
+def load_data(owner: str, repo: str, branch: str, path: str):
+    if owner:
+        url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
+        try:
+            return pd.read_excel(url, engine="openpyxl")
+        except Exception:
+            st.warning("Falha ao carregar do GitHub.")
+    try:
+        return pd.read_excel(path, engine="openpyxl")
+    except Exception:
+        return None
+
+df = load_data(owner, repo, branch, path)
+if df is None:
+    uploaded = st.file_uploader("Envie a planilha resultado_eduardo_veiculos.xlsx", type="xlsx")
+    if uploaded:
+        df = pd.read_excel(uploaded, engine="openpyxl")
+
+if df is None:
+    st.stop()
+
+df = prepare_dataframe(df)
+realizado = compute_realizado(df)
+last_month = int(realizado[realizado["FAT"] > 0].index.max() or 0)
+
+def fmt_brl(v: float) -> str:
+    return f"R$ {v:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+pagina = st.sidebar.selectbox("Página", ["Dashboard", "Simulação", "Notas/Detalhes"])
+
+if pagina == "Dashboard":
+    ano = st.sidebar.selectbox("Ano", [2025], index=0)
+    mes = st.sidebar.selectbox("Mês", list(range(1, 13)), index=max(last_month - 1, 0))
+    linha = realizado.loc[mes]
+    col1, col2, col3, col4, col5 = st.columns(5)
+    col1.metric("Entradas", fmt_brl(linha["CMV"]))
+    col2.metric("Saídas", fmt_brl(linha["FAT"]))
+    col3.metric("LAT", fmt_brl(linha["LAT"]))
+    col4.metric("Lucro Líquido", fmt_brl(linha["LL"]))
+    col5.metric("Consumo", fmt_brl(linha["CONSUMO"]))
+    mensal = realizado.copy()
+    mensal["Tributos"] = mensal[["PIS", "COFINS", "ICMS", "IRPJ", "CSLL"]].sum(axis=1)
+    fig = px.bar(mensal, x=mensal.index, y=["FAT", "CMV", "CONSUMO", "LAT", "Tributos", "LL"], barmode="stack")
+    fig.update_layout(xaxis_title="Mês", yaxis_title="R$")
+    st.plotly_chart(fig, use_container_width=True)
+
+elif pagina == "Simulação":
+    st.header("Simulação 2025")
+    lat_meta = st.number_input("Meta LAT Anual (R$)", min_value=0.0, step=1000.0)
+    margens_opts = [0.05, 0.10, 0.15, 0.20, 0.25, 0.30]
+    margens = [m for m in margens_opts if st.checkbox(f"Margem {int(m*100)}%", True, key=f"m_{m}")]
+    sim_mes_atual = st.checkbox("Simular mês vigente", False)
+    meses_sim = list(range(last_month + 1, 13))
+    locked = list(range(1, last_month + 1))
+    if sim_mes_atual:
+        meses_sim = list(range(last_month, 13))
+        locked = list(range(1, last_month))
+    manual = st.checkbox("Distribuição manual por mês", False)
+    distrib = {}
+    if manual:
+        st.write("Distribuição (% do LAT restante)")
+        total = 0
+        for mes in meses_sim:
+            val = st.slider(f"Mês {mes:02d}", 0, 100, value=int(100 / len(meses_sim)), key=f"d_{mes}")
+            distrib[mes] = val
+            total += val
+        if total > 0:
+            distrib = {k: v / total for k, v in distrib.items()}
+        else:
+            distrib = None
+    else:
+        distrib = None
+    resultados = simulate(realizado, lat_meta, margens, meses_sim, distrib)
+    for margem, dfm in resultados.items():
+        st.subheader(f"Margem {int(margem*100)}%")
+        df_show = dfm.copy()
+        df_show["Tributos"] = df_show[["PIS", "COFINS", "ICMS", "IRPJ", "CSLL"]].sum(axis=1)
+        total = df_show.sum()
+        df_show = pd.concat([df_show, total.to_frame().T], ignore_index=False)
+        df_show.index = list(range(1, 13)) + ["Total"]
+        st.dataframe(df_show)
+        if (df_show.loc[1:12, "LL"] < 0).any():
+            st.warning("Lucro Líquido negativo em algum mês.")
+        csv = df_show.to_csv().encode("utf-8")
+        st.download_button("Exportar CSV", csv, f"simulacao_{int(margem*100)}.csv", "text/csv")
+        towrite = BytesIO()
+        with pd.ExcelWriter(towrite, engine="openpyxl") as writer:
+            df_show.to_excel(writer, index=True)
+        st.download_button(
+            "Exportar XLSX",
+            towrite.getvalue(),
+            f"simulacao_{int(margem*100)}.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        try:
+            from reportlab.lib.pagesizes import A4
+            from reportlab.pdfgen import canvas
+            pdf_buffer = BytesIO()
+            c = canvas.Canvas(pdf_buffer, pagesize=A4)
+            c.drawString(30, 800, f"Simulação margem {int(margem*100)}%")
+            text = c.beginText(30, 780)
+            for line in df_show.to_string().split("\n"):
+                text.textLine(line)
+            c.drawText(text)
+            c.showPage()
+            c.save()
+            pdf_buffer.seek(0)
+            st.download_button(
+                "Exportar PDF",
+                pdf_buffer,
+                f"simulacao_{int(margem*100)}.pdf",
+                "application/pdf",
+            )
+        except Exception:
+            st.info("reportlab não disponível para PDF.")
+elif pagina == "Notas/Detalhes":
+    st.header("Notas/Detalhes")
+    meses = st.multiselect("Mês", sorted(df["mes"].unique()), default=sorted(df["mes"].unique()))
+    tipos = st.multiselect("Tipo Nota", sorted(df["tipo_nota"].unique()), default=sorted(df["tipo_nota"].unique()))
+    classifs = st.multiselect("Classificação", sorted(df["classificacao"].unique()), default=sorted(df["classificacao"].unique()))
+    filtrado = df[df["mes"].isin(meses) & df["tipo_nota"].isin(tipos) & df["classificacao"].isin(classifs)]
+    st.dataframe(filtrado)
+    csv = filtrado.to_csv(index=False).encode("utf-8")
+    st.download_button("Download CSV", csv, "notas_filtradas.csv", "text/csv")
+    towrite = BytesIO()
+    with pd.ExcelWriter(towrite, engine="openpyxl") as writer:
+        filtrado.to_excel(writer, index=False)
+    st.download_button(
+        "Download XLSX",
+        towrite.getvalue(),
+        "notas_filtradas.xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+APP
+fi
+if [ ! -f calc.py ]; then
+  cat <<'CALC' > calc.py
+from __future__ import annotations
+from typing import Dict, Sequence, Optional
+import pandas as pd
+import numpy as np
+
+COL_MAP = {
+    "cfop": "cfop",
+    "data emissão": "data_emissao",
+    "emitente cnpj/cpf": "emitente",
+    "destinatário cnpj/cpf": "destinatario",
+    "chassi": "chassi",
+    "placa": "placa",
+    "produto": "produto",
+    "valor total": "valor_total",
+    "renavam": "renavam",
+    "km": "km",
+    "ano modelo": "ano_modelo",
+    "ano fabricação": "ano_fabricacao",
+    "cor": "cor",
+    "icms alíquota": "icms_aliquota",
+    "icms valor": "icms_valor",
+    "icms base": "icms_base",
+    "cst icms": "cst_icms",
+    "redução bc": "reducao_bc",
+    "modalidade bc": "modalidade_bc",
+    "natureza operação": "natureza_operacao",
+    "chave xml": "chave_xml",
+    "xml path": "xml_path",
+    "item": "item",
+    "número nf": "numero_nf",
+    "tipo nota": "tipo_nota",
+    "classificação": "classificacao",
+    "combustível": "combustivel",
+    "motor": "motor",
+    "modelo": "modelo",
+    "potência": "potencia",
+}
+
+def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normaliza colunas e tipos do DataFrame de notas."""
+    cols_lower = {c.lower(): c for c in df.columns}
+    rename_map = {}
+    for k, v in COL_MAP.items():
+        if k in cols_lower:
+            rename_map[cols_lower[k]] = v
+    df = df.rename(columns=rename_map)
+    for col in ["valor_total", "data_emissao", "tipo_nota", "classificacao", "natureza_operacao"]:
+        if col not in df.columns:
+            df[col] = np.nan
+    df["valor_total"] = (
+        df["valor_total"].astype(str).str.replace(".", "", regex=False).str.replace(",", ".", regex=False)
+    )
+    df["valor_total"] = pd.to_numeric(df["valor_total"], errors="coerce").fillna(0.0)
+    df["data_emissao"] = pd.to_datetime(df["data_emissao"], errors="coerce", dayfirst=True)
+    df["ano"] = df["data_emissao"].dt.year
+    df["mes"] = df["data_emissao"].dt.month
+    df["yyyymm"] = df["data_emissao"].dt.strftime("%Y%m").astype(float).fillna(0).astype(int)
+    df["tipo_nota"] = df["tipo_nota"].astype(str).str.strip().str.casefold()
+    df["classificacao"] = df["classificacao"].astype(str).str.strip().str.casefold()
+    df["natureza_operacao"] = df["natureza_operacao"].astype(str).str.strip().str.casefold()
+    return df
+
+def apurar_irpj_csll_trimestral(df: pd.DataFrame, locked_months: Optional[Sequence[int]] = None) -> pd.DataFrame:
+    """Calcula IRPJ e CSLL trimestrais com rateio mensal."""
+    df = df.copy().reindex(range(1,13), fill_value=0.0)
+    df["Base"] = 0.32 * df["LAT"]
+    df["IRPJ"] = df.get("IRPJ", 0.0)
+    df["CSLL"] = df.get("CSLL", 0.0)
+    locked = set(locked_months or [])
+    trimestres = [(1, [1, 2, 3]), (2, [4, 5, 6]), (3, [7, 8, 9]), (4, [10, 11, 12])]
+    for _, meses in trimestres:
+        base_tri = df.loc[meses, "Base"].sum()
+        if base_tri == 0:
+            df.loc[meses, ["IRPJ", "CSLL"]] = 0.0
+            continue
+        irpj_total = 0.15 * base_tri
+        if base_tri > 60000:
+            irpj_total += 0.10 * (base_tri - 60000)
+        csll_total = 0.09 * base_tri
+        meses_locked = [m for m in meses if m in locked]
+        meses_livres = [m for m in meses if m not in locked]
+        irpj_locked = df.loc[meses_locked, "IRPJ"].sum()
+        csll_locked = df.loc[meses_locked, "CSLL"].sum()
+        base_livre = df.loc[meses_livres, "Base"].sum()
+        irpj_restante = max(irpj_total - irpj_locked, 0.0)
+        csll_restante = max(csll_total - csll_locked, 0.0)
+        if meses_livres and base_livre > 0:
+            df.loc[meses_livres, "IRPJ"] = irpj_restante * df.loc[meses_livres, "Base"] / base_livre
+            df.loc[meses_livres, "CSLL"] = csll_restante * df.loc[meses_livres, "Base"] / base_livre
+    return df
+
+def compute_realizado(df: pd.DataFrame) -> pd.DataFrame:
+    """Consolida valores realizados de 2025 por mês."""
+    df = prepare_dataframe(df)
+    df = df[df["ano"] == 2025]
+    mask_devol = df["natureza_operacao"].str.contains("devolucao de compra")
+    mask_saida = df["tipo_nota"] == "saída"
+    mask_entrada = df["tipo_nota"] == "entrada"
+    mask_cmv = mask_entrada & (df["classificacao"] == "mercadoria para revenda")
+    mask_consumo = mask_entrada & (df["classificacao"] == "consumo")
+    mensal = pd.DataFrame(index=range(1, 13), columns=["FAT", "CMV", "CONSUMO"], data=0.0)
+    mensal["FAT"] = df[mask_saida & ~mask_devol].groupby("mes")["valor_total"].sum()
+    mensal["CMV"] = df[mask_cmv].groupby("mes")["valor_total"].sum()
+    mensal["CMV"] -= df[mask_devol].groupby("mes")["valor_total"].sum().reindex(mensal.index, fill_value=0)
+    mensal["CONSUMO"] = df[mask_consumo].groupby("mes")["valor_total"].sum()
+    mensal = mensal.fillna(0.0)
+    mensal["LB"] = mensal["FAT"] - mensal["CMV"]
+    mensal["LAT"] = mensal["LB"] - mensal["CONSUMO"]
+    mensal["PIS"] = 0.0065 * mensal["LAT"]
+    mensal["COFINS"] = 0.03 * mensal["LAT"]
+    mensal["ICMS"] = 0.05 * mensal["FAT"]
+    mensal = apurar_irpj_csll_trimestral(mensal)
+    mensal["LL"] = mensal["LAT"] - (mensal["PIS"] + mensal["COFINS"] + mensal["ICMS"] + mensal["IRPJ"] + mensal["CSLL"])
+    mensal["Compras"] = mensal["CMV"]
+    mensal["yyyymm"] = [202500 + i for i in range(1, 13)]
+    return mensal
+
+def simulate(
+    realizado: pd.DataFrame,
+    lat_meta_anual: float,
+    margins: Sequence[float],
+    months_to_simulate: Sequence[int],
+    distribution: Optional[Dict[int, float]] = None,
+) -> Dict[float, pd.DataFrame]:
+    """Simula meses futuros para atingir LAT anual."""
+    meses_sim = list(months_to_simulate)
+    locked = set(range(1, 13)) - set(meses_sim)
+    lat_realizado = realizado.loc[sorted(locked), "LAT"].sum()
+    lat_restante = max(lat_meta_anual - lat_realizado, 0.0)
+    if distribution is None:
+        distribution = {m: 1 / len(meses_sim) for m in meses_sim}
+    else:
+        total = sum(distribution.values())
+        distribution = {m: distribution.get(m, 0) / total for m in meses_sim}
+    resultados: Dict[float, pd.DataFrame] = {}
+    for margem in margins:
+        df = realizado.copy()
+        for mes in meses_sim:
+            lat_mes = lat_restante * distribution[mes]
+            fat = lat_mes / margem if margem else 0.0
+            cmv = fat - lat_mes
+            df.loc[mes, "FAT"] = fat
+            df.loc[mes, "CMV"] = cmv
+            df.loc[mes, "CONSUMO"] = 0.0
+            df.loc[mes, "LB"] = fat - cmv
+            df.loc[mes, "LAT"] = lat_mes
+            df.loc[mes, "PIS"] = 0.0065 * lat_mes
+            df.loc[mes, "COFINS"] = 0.03 * lat_mes
+            df.loc[mes, "ICMS"] = 0.05 * fat
+            df.loc[mes, ["IRPJ", "CSLL"]] = 0.0
+        df = apurar_irpj_csll_trimestral(df, locked_months=locked)
+        df["LL"] = df["LAT"] - (df["PIS"] + df["COFINS"] + df["ICMS"] + df["IRPJ"] + df["CSLL"])
+        df["Compras"] = df["CMV"]
+        resultados[margem] = df
+    return resultados
+
+if __name__ == "__main__":
+    # Cenário 1
+    df1 = pd.DataFrame(
+        {
+            "Data Emissão": ["01/01/2025", "01/01/2025"],
+            "Valor Total": ["200000,00", "100000,00"],
+            "Tipo Nota": ["Saída", "Entrada"],
+            "Classificação": ["", "MERCADORIA PARA REVENDA"],
+            "Natureza Operação": ["Venda", "Compra"],
+        }
+    )
+    real = compute_realizado(df1)
+    assert round(real.at[1, "PIS"], 2) == 650.00
+    assert round(real.at[1, "COFINS"], 2) == 3000.00
+    assert round(real.at[1, "ICMS"], 2) == 10000.00
+
+    # Cenário 2
+    tri = pd.DataFrame(index=[1, 2, 3], data={"LAT": [83333.33, 83333.33, 83333.34]})
+    tri = apurar_irpj_csll_trimestral(tri)
+    assert round(tri["IRPJ"].sum(), 2) == 14000.00
+    assert round(tri["CSLL"].sum(), 2) == 7200.00
+
+    # Cenário 3
+    vazio = pd.DataFrame(
+        index=range(1, 13),
+        columns=[
+            "FAT",
+            "CMV",
+            "CONSUMO",
+            "LB",
+            "LAT",
+            "PIS",
+            "COFINS",
+            "ICMS",
+            "IRPJ",
+            "CSLL",
+            "LL",
+            "Compras",
+        ],
+        data=0.0,
+    )
+    sim = simulate(vazio, 50000.0, [0.20], [1])[0.20]
+    assert round(sim.at[1, "FAT"], 2) == 250000.00
+    assert round(sim.at[1, "CMV"], 2) == 200000.00
+    print("Testes rápidos OK!")
+CALC
+fi
+echo "Bootstrap concluído"

--- a/calc.py
+++ b/calc.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+from typing import Dict, Sequence, Optional, Tuple, List
+import pandas as pd
+import numpy as np
+
+COL_MAP = {
+    "cfop": "cfop",
+    "data emissão": "data_emissao",
+    "emitente cnpj/cpf": "emitente",
+    "destinatário cnpj/cpf": "destinatario",
+    "chassi": "chassi",
+    "placa": "placa",
+    "produto": "produto",
+    "valor total": "valor_total",
+    "renavam": "renavam",
+    "km": "km",
+    "ano modelo": "ano_modelo",
+    "ano fabricação": "ano_fabricacao",
+    "cor": "cor",
+    "icms alíquota": "icms_aliquota",
+    "icms valor": "icms_valor",
+    "icms base": "icms_base",
+    "cst icms": "cst_icms",
+    "redução bc": "reducao_bc",
+    "modalidade bc": "modalidade_bc",
+    "natureza operação": "natureza_operacao",
+    "chave xml": "chave_xml",
+    "xml path": "xml_path",
+    "item": "item",
+    "número nf": "numero_nf",
+    "tipo nota": "tipo_nota",
+    "classificação": "classificacao",
+    "combustível": "combustivel",
+    "motor": "motor",
+    "modelo": "modelo",
+    "potência": "potencia",
+}
+
+def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normaliza colunas e tipos do DataFrame de notas."""
+    cols_lower = {c.lower(): c for c in df.columns}
+    rename_map = {}
+    for k, v in COL_MAP.items():
+        if k in cols_lower:
+            rename_map[cols_lower[k]] = v
+    df = df.rename(columns=rename_map)
+    for col in ["valor_total", "data_emissao", "tipo_nota", "classificacao", "natureza_operacao"]:
+        if col not in df.columns:
+            df[col] = np.nan
+    df["valor_total"] = (
+        df["valor_total"].astype(str).str.replace(".", "", regex=False).str.replace(",", ".", regex=False)
+    )
+    df["valor_total"] = pd.to_numeric(df["valor_total"], errors="coerce").fillna(0.0)
+    df["data_emissao"] = pd.to_datetime(df["data_emissao"], errors="coerce", dayfirst=True)
+    df["ano"] = df["data_emissao"].dt.year
+    df["mes"] = df["data_emissao"].dt.month
+    df["yyyymm"] = df["data_emissao"].dt.strftime("%Y%m").astype(float).fillna(0).astype(int)
+    df["tipo_nota"] = df["tipo_nota"].astype(str).str.strip().str.casefold()
+    df["classificacao"] = df["classificacao"].astype(str).str.strip().str.casefold()
+    df["natureza_operacao"] = df["natureza_operacao"].astype(str).str.strip().str.casefold()
+    return df
+
+def apurar_irpj_csll_trimestral(df: pd.DataFrame, locked_months: Optional[Sequence[int]] = None) -> pd.DataFrame:
+    """Calcula IRPJ e CSLL trimestrais com rateio mensal."""
+    df = df.copy().reindex(range(1,13), fill_value=0.0)
+    df["Base"] = 0.32 * df["LAT"]
+    df["IRPJ"] = df.get("IRPJ", 0.0)
+    df["CSLL"] = df.get("CSLL", 0.0)
+    locked = set(locked_months or [])
+    trimestres = [(1, [1, 2, 3]), (2, [4, 5, 6]), (3, [7, 8, 9]), (4, [10, 11, 12])]
+    for _, meses in trimestres:
+        base_tri = df.loc[meses, "Base"].sum()
+        if base_tri == 0:
+            df.loc[meses, ["IRPJ", "CSLL"]] = 0.0
+            continue
+        irpj_total = 0.15 * base_tri
+        if base_tri > 60000:
+            irpj_total += 0.10 * (base_tri - 60000)
+        csll_total = 0.09 * base_tri
+        meses_locked = [m for m in meses if m in locked]
+        meses_livres = [m for m in meses if m not in locked]
+        irpj_locked = df.loc[meses_locked, "IRPJ"].sum()
+        csll_locked = df.loc[meses_locked, "CSLL"].sum()
+        base_livre = df.loc[meses_livres, "Base"].sum()
+        irpj_restante = max(irpj_total - irpj_locked, 0.0)
+        csll_restante = max(csll_total - csll_locked, 0.0)
+        if meses_livres and base_livre > 0:
+            df.loc[meses_livres, "IRPJ"] = irpj_restante * df.loc[meses_livres, "Base"] / base_livre
+            df.loc[meses_livres, "CSLL"] = csll_restante * df.loc[meses_livres, "Base"] / base_livre
+    return df
+
+def compute_realizado(df: pd.DataFrame) -> pd.DataFrame:
+    """Consolida valores realizados de 2025 por mês."""
+    df = prepare_dataframe(df)
+    df = df[df["ano"] == 2025]
+    mask_devol = df["natureza_operacao"].str.contains("devolucao de compra")
+    mask_saida = df["tipo_nota"] == "saída"
+    mask_entrada = df["tipo_nota"] == "entrada"
+    mask_cmv = mask_entrada & (df["classificacao"] == "mercadoria para revenda")
+    mask_consumo = mask_entrada & (df["classificacao"] == "consumo")
+    mensal = pd.DataFrame(index=range(1, 13), columns=["FAT", "CMV", "CONSUMO"], data=0.0)
+    mensal["FAT"] = df[mask_saida & ~mask_devol].groupby("mes")["valor_total"].sum()
+    mensal["CMV"] = df[mask_cmv].groupby("mes")["valor_total"].sum()
+    mensal["CMV"] -= df[mask_devol].groupby("mes")["valor_total"].sum().reindex(mensal.index, fill_value=0)
+    mensal["CONSUMO"] = df[mask_consumo].groupby("mes")["valor_total"].sum()
+    mensal = mensal.fillna(0.0)
+    mensal["LB"] = mensal["FAT"] - mensal["CMV"]
+    mensal["LAT"] = mensal["LB"] - mensal["CONSUMO"]
+    mensal["PIS"] = 0.0065 * mensal["LAT"]
+    mensal["COFINS"] = 0.03 * mensal["LAT"]
+    mensal["ICMS"] = 0.05 * mensal["FAT"]
+    mensal = apurar_irpj_csll_trimestral(mensal)
+    mensal["LL"] = mensal["LAT"] - (mensal["PIS"] + mensal["COFINS"] + mensal["ICMS"] + mensal["IRPJ"] + mensal["CSLL"])
+    mensal["Compras"] = mensal["CMV"]
+    mensal["yyyymm"] = [202500 + i for i in range(1, 13)]
+    return mensal
+
+
+def calc_mes(lat: float) -> Dict[str, Dict]:
+    """Calcula tributos e cenários de faturamento para um LAT mensal."""
+    pis = 0.0065 * lat
+    cofins = 0.03 * lat
+    margens = [0.05, 0.10, 0.15, 0.20, 0.25, 0.30]
+    cenarios: Dict[float, Dict[str, float]] = {}
+    for m in margens:
+        fat = lat / m if m else 0.0
+        compras = fat - lat
+        icms = 0.05 * fat
+        cenarios[m] = {"FAT": fat, "COMPRAS": compras, "ICMS": icms}
+    return {"PIS": pis, "COFINS": cofins, "cenarios": cenarios}
+
+
+def irpj_csll_trimestre(lat_por_mes: Dict[int, float], tri_key: str) -> Tuple[float, float, int]:
+    """Retorna IRPJ, CSLL totais do trimestre e mês de fechamento."""
+    ano = int(tri_key[:4])
+    tri = int(tri_key[-1])
+    mapa = {1: [1, 2, 3], 2: [4, 5, 6], 3: [7, 8, 9], 4: [10, 11, 12]}
+    meses = [ano * 100 + m for m in mapa[tri]]
+    bases = [0.32 * lat_por_mes.get(m, 0.0) for m in meses]
+    base_total = sum(bases)
+    irpj = 0.15 * base_total
+    if base_total > 60000:
+        irpj += 0.10 * (base_total - 60000)
+    csll = 0.09 * base_total
+    fechamento = meses[-1]
+    return irpj, csll, fechamento
+
+
+def ultimo_yyyymm(df: pd.DataFrame) -> int:
+    """Retorna o último yyyymm encontrado no DataFrame."""
+    if "yyyymm" in df.columns and not df["yyyymm"].dropna().empty:
+        return int(df["yyyymm"].dropna().astype(int).max())
+    return 0
+
+
+def meses_simulaveis(ultimo: int) -> List[int]:
+    """Lista meses yyyymm posteriores ao último mês realizado."""
+    return [m for m in range(202501, 202513) if m > ultimo]
+
+
+def trimestre_de(mes: int) -> str:
+    """Retorna a chave do trimestre (YYYYQn) para um yyyymm."""
+    q = ((mes % 100 - 1) // 3) + 1
+    return f"{mes // 100}Q{q}"
+
+
+def progresso_trimestre(lat_por_mes: Dict[int, float], tri_key: str) -> Tuple[int, int, List[int]]:
+    """Avalia o progresso do trimestre: meses preenchidos e faltantes."""
+    ano = int(tri_key[:4])
+    tri = int(tri_key[-1])
+    mapa = {1: [1, 2, 3], 2: [4, 5, 6], 3: [7, 8, 9], 4: [10, 11, 12]}
+    meses = [ano * 100 + m for m in mapa[tri]]
+    preenchidos = [m for m in meses if lat_por_mes.get(m, 0.0) > 0]
+    faltantes = [m for m in meses if lat_por_mes.get(m, 0.0) <= 0]
+    return len(preenchidos), len(meses), faltantes
+
+if __name__ == "__main__":
+    # Cenário 1
+    res = calc_mes(100000.0)
+    assert round(res["PIS"], 2) == 650.00
+    assert round(res["COFINS"], 2) == 3000.00
+    cen20 = res["cenarios"][0.20]
+    assert round(cen20["FAT"], 2) == 500000.00
+    assert round(cen20["COMPRAS"], 2) == 400000.00
+    assert round(cen20["ICMS"], 2) == 25000.00
+
+    # Cenário 2
+    lat_mes = {202501: 83333.33, 202502: 83333.33, 202503: 83333.34}
+    irpj, csll, fechamento = irpj_csll_trimestre(lat_mes, "2025Q1")
+    assert round(irpj, 2) == 14000.00
+    assert round(csll, 2) == 7200.00
+    assert fechamento == 202503
+
+    # Cenário 3
+    prog0 = progresso_trimestre({}, "2025Q1")
+    assert prog0[0] == 0
+    prog2 = progresso_trimestre({202501: 1000.0, 202502: 1000.0}, "2025Q1")
+    assert prog2[0] == 2
+    prog3 = progresso_trimestre(lat_mes, "2025Q1")
+    assert prog3[0] == 3
+    print("Testes rápidos OK!")

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from calc import calc_mes, irpj_csll_trimestre, progresso_trimestre
+
+
+def test_calc_mes_basico():
+    res = calc_mes(100000.0)
+    assert res["PIS"] == pytest.approx(650.0)
+    assert res["COFINS"] == pytest.approx(3000.0)
+    cen = res["cenarios"][0.20]
+    assert cen["FAT"] == pytest.approx(500000.0)
+    assert cen["COMPRAS"] == pytest.approx(400000.0)
+    assert cen["ICMS"] == pytest.approx(25000.0)
+
+
+def test_irpj_csll_trimestre():
+    lat = {202501: 83333.33, 202502: 83333.33, 202503: 83333.34}
+    irpj, csll, fechamento = irpj_csll_trimestre(lat, "2025Q1")
+    assert irpj == pytest.approx(14000.0)
+    assert csll == pytest.approx(7200.0)
+    assert fechamento == 202503
+
+
+def test_progresso_trimestre():
+    lat = {202501: 1000.0, 202502: 0.0, 202503: 1000.0}
+    prog, total, falt = progresso_trimestre(lat, "2025Q1")
+    assert total == 3
+    assert prog == 2
+    assert falt == [202502]


### PR DESCRIPTION
## Resumo
- Adiciona utilitários de cálculo mensal e trimestral com cenários por margem e progresso de trimestre.
- Reestrutura página de simulação com chips de meses, cards de margens/tributos e apuração de IRPJ/CSLL apenas nos fechamentos.
- Define tema visual via `.streamlit/config.toml` e amplia testes unitários.

## Testes
- `pytest -q`
- `python calc.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf2eb354c832688d2c72bcaa6bd9d