### PR TITLE
Normalize fiscal data and fix LAT editor

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,6 @@
 [theme]
-primaryColor = "#0A84FF"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#F6F8FC"
-textColor = "#0F172A"
-font = "sans serif"
+primaryColor="#0A84FF"
+backgroundColor="#FFFFFF"
+secondaryBackgroundColor="#F6F8FC"
+textColor="#0F172A"
+font="sans serif"


### PR DESCRIPTION
## Summary
- normalize text fields and group monthly data to avoid missing FAT figures
- ensure LAT editor uses float values with safe formatting
- add Streamlit theme and regression tests for fiscal calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e3233afcc83268827647d88909641